### PR TITLE
small code example correction: ServerConfig.port accepts a number, rather than a string 

### DIFF
--- a/docs/documentation/overview.md
+++ b/docs/documentation/overview.md
@@ -32,7 +32,7 @@ Each infrastructure endpoints share the same constructor.
 const accountHttp = new AccountHttp([{
     protocol: "http",
     domain: "104.128.226.60",
-    port: "7890"
+    port: 7890
 }]);
 
 // Using default NIS Node


### PR DESCRIPTION
the `ServerConfig.port` attribute accepts a `number` paramether (rather than a `string` parameter):

```
export interface ServerConfig {
    readonly protocol?: Protocol;
    readonly domain: string;
    readonly port?: number;
}
```